### PR TITLE
changes import ustruct to struct

### DIFF
--- a/adafruit_register/i2c_struct.py
+++ b/adafruit_register/i2c_struct.py
@@ -22,7 +22,7 @@
 
 try:
     import struct
-except:
+except ImportError:
     import ustruct as struct
 
 class Struct:

--- a/adafruit_register/i2c_struct.py
+++ b/adafruit_register/i2c_struct.py
@@ -20,7 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-import ustruct
+try:
+    import struct
+except:
+    import ustruct as struct
 
 class Struct:
     """
@@ -34,17 +37,17 @@ class Struct:
     """
     def __init__(self, register_address, struct_format):
         self.format = struct_format
-        self.buffer = bytearray(1+ustruct.calcsize(self.format))
+        self.buffer = bytearray(1+struct.calcsize(self.format))
         self.buffer[0] = register_address
 
     def __get__(self, obj, objtype=None):
         with obj.i2c_device:
             obj.i2c_device.write(self.buffer, end=1, stop=False)
             obj.i2c_device.read_into(self.buffer, start=1)
-        return ustruct.unpack_from(self.format, memoryview(self.buffer)[1:])
+        return struct.unpack_from(self.format, memoryview(self.buffer)[1:])
 
     def __set__(self, obj, value):
-        ustruct.pack_into(self.format, self.buffer, 1, *value)
+        struct.pack_into(self.format, self.buffer, 1, *value)
         with obj.i2c_device:
             obj.i2c_device.write(self.buffer)
 
@@ -60,16 +63,16 @@ class UnaryStruct:
     """
     def __init__(self, register_address, struct_format):
         self.format = struct_format
-        self.buffer = bytearray(1+ustruct.calcsize(self.format))
+        self.buffer = bytearray(1+struct.calcsize(self.format))
         self.buffer[0] = register_address
 
     def __get__(self, obj, objtype=None):
         with obj.i2c_device:
             obj.i2c_device.write(self.buffer, end=1, stop=False)
             obj.i2c_device.read_into(self.buffer, start=1)
-        return ustruct.unpack_from(self.format, memoryview(self.buffer)[1:])[0]
+        return struct.unpack_from(self.format, memoryview(self.buffer)[1:])[0]
 
     def __set__(self, obj, value):
-        ustruct.pack_into(self.format, self.buffer, 1, value)
+        struct.pack_into(self.format, self.buffer, 1, value)
         with obj.i2c_device:
             obj.i2c_device.write(self.buffer)


### PR DESCRIPTION
as a result of Refine `ustruct` into `struct` in shared-bindings and shared-module. #205