### PR TITLE
Re-add index contents

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,17 +1,41 @@
+.. _register-module-reference:
 
-.. If you created a package, create one automodule per module in the package.
+Module Reference
+================
+
+I2C
+---
+
+`i2c_bit` - Single bit registers
+++++++++++++++++++++++++++++++++
 
 .. automodule:: adafruit_register.i2c_bit
    :members:
 
+`i2c_bits` - Multi bit registers
+++++++++++++++++++++++++++++++++
+
 .. automodule:: adafruit_register.i2c_bits
-   :members:
+    :members:
+
+`i2c_struct` - Generic structured registers based on `struct`
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. automodule:: adafruit_register.i2c_struct
-   :members:
+    :members:
+
+`i2c_bcd_datetime` - Binary Coded Decimal date and time register
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. automodule:: adafruit_register.i2c_bcd_datetime
-   :members:
+  :members:
+
+`i2c_bcd_alarm` - Binary Coded Decimal alarm register
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. automodule:: adafruit_register.i2c_bcd_alarm
-   :members:
+  :members:
+
+SPI
+---
+Coming soon!


### PR DESCRIPTION
Removing the `.. _register-module-reference:` broke other docs builds which referred to the section.