### PR TITLE
Don't use offset kwd in struct.unpack_from()

### DIFF
--- a/adafruit_register/i2c_struct_array.py
+++ b/adafruit_register/i2c_struct_array.py
@@ -68,7 +68,7 @@ class _BoundStructArray:
         with self.obj.i2c_device:
             self.obj.i2c_device.write(buf, end=1, stop=False)
             self.obj.i2c_device.readinto(buf, start=1)
-        return struct.unpack_from(self.format, buf, offset=1)
+        return struct.unpack_from(self.format, buf, 1)  # offset=1
 
     def __setitem__(self, index, value):
         buf = self._get_buffer(index)


### PR DESCRIPTION
Workaround for https://github.com/adafruit/circuitpython/issues/984 not being fixed yet. Leave this in since it will work for builds before that fix happens as well.

Also would have fixed https://github.com/adafruit/Adafruit_CircuitPython_Motor/issues/11, which accidentally no longer throws an error due to https://github.com/adafruit/Adafruit_CircuitPython_Motor/pull/10.