### PR TITLE
Update README Travis Badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,8 +10,8 @@ Introduction
     :target: https://discord.gg/nBQh6qu
     :alt: Discord
 
-.. image:: https://travis-ci.org/adafruit/Adafruit_CircuitPython_Register.svg?branch=master
-    :target: https://travis-ci.org/adafruit/Adafruit_CircuitPython_Register
+.. image:: https://travis-ci.com/adafruit/Adafruit_CircuitPython_Register.svg?branch=master
+    :target: https://travis-ci.com/adafruit/Adafruit_CircuitPython_Register
     :alt: Build Status
 
 This library provides a variety of data descriptor class for `Adafruit


### PR DESCRIPTION
Change 'travis-ci.org' to 'travis-ci.com'.