### PR TITLE
Got README.rst to render in PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ Next, define where the bit is located in the device's memory map:
         world = i2c_bit.RWBit(0x1, 0x0)
         """Bit to indicate if world is lit."""
 
-Lastly, we need to add an ``i2c_device`` member of type :class:`~adafruit_bus_device.i2c_device.I2CDevice`
+Lastly, we need to add an ``i2c_device`` member of type `I2CDevice <https://circuitpython.readthedocs.io/projects/busdevice/en/latest/api.html#adafruit_bus_device.i2c_device.I2CDevice>`_
 that manages sharing the I2C bus for us. Make sure the name is exact, otherwise
 the registers will not be able to find it. Also, make sure that the i2c device
 implements the `busio.I2C` interface.
@@ -177,7 +177,7 @@ we must implement ``__get__`` and ``__set__``.
 As you can see, we have two places to get state from. First, ``self`` stores the
 register class members which locate the register within the device memory map.
 Second, ``obj`` is the driver class that uses the register class which must by
-definition provide a :class:`~adafruit_bus_device.i2c_device.I2CDevice` compatible
+definition provide a `I2CDevice <https://circuitpython.readthedocs.io/projects/busdevice/en/latest/api.html#adafruit_bus_device.i2c_device.I2CDevice>`_ compatible
 object as ``i2c_device``. This object does two thing for us:
 
   1. Waits for the bus to free, locks it as we use it and frees it after.


### PR DESCRIPTION
Here's what it looked like previously (bold things in boxes are links that only Sphinx can render):
![register_old](https://user-images.githubusercontent.com/33632497/73084780-94788200-3e9b-11ea-89a9-316393ca6297.png)

Here's what it looks like after my changes:
![register_new](https://user-images.githubusercontent.com/33632497/73084778-93dfeb80-3e9b-11ea-865b-cc63b0b5e6dd.png)

If you can think of a better way to do this, I'd love to hear it, because I feel like there's got to be a better way to do this. I'd also really like to make the formatting closer to what it originally was, but all the solutions I've found online only work with sphinx.

I have tested this locally and the links all work the same as they did previously

Here's the zip file of my local build of the docs:
[html.zip](https://github.com/adafruit/Adafruit_CircuitPython_Register/files/4109470/html.zip)




