### PR TITLE
adding simple bit and bits for SPI devices

### DIFF
--- a/adafruit_register/spi_bit.py
+++ b/adafruit_register/spi_bit.py
@@ -1,0 +1,83 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 Scott Shawcroft for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# pylint: disable=too-few-public-methods
+"""
+`adafruit_register.spi_bit`
+====================================================
+
+Single bit registers
+
+* Author(s): Scott Shawcroft
+* Adaptation by Max Holliday
+"""
+
+
+class RWBit:
+    """
+    Single bit register that is readable and writeable.
+
+    Values are `bool`
+
+    :param int register_address: The register address to read the bit from
+    :param type bit: The bit index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+    :param bool lsb_first: Is the first byte we read from spi the LSB? Defaults to true
+
+    """
+    def __init__(self, register_address, bit, register_width=1, lsb_first=True):
+        self.bit_mask = 1 << (bit%8) # the bitmask *within* the byte!
+        self.buffer = bytearray(1 + register_width)
+        self.buffer[0] = register_address
+        self.buffer[1] = register_width-1
+        if lsb_first:
+            self.byte = bit // 8 + 1  # the byte number within the buffer
+        else:
+            self.byte = register_width - (bit // 8) # the byte number within the buffer
+
+    def __get__(self, obj, objtype=None):
+        with obj.spi_device as spi:
+            spi.write(self.buffer,end=2)
+            spi.readinto(self.buffer,start=1)
+        return bool(self.buffer[self.byte] & self.bit_mask)
+
+    def __set__(self, obj, value):
+        with obj.spi_device as spi:
+            spi.write(self.buffer,end=2)
+            spi.readinto(self.buffer,start=1)
+            if value:
+                self.buffer[self.byte] |= self.bit_mask
+            else:
+                self.buffer[self.byte] &= ~self.bit_mask
+            spi.write(self.buffer)
+
+class ROBit(RWBit):
+    """Single bit register that is read only. Subclass of `RWBit`.
+
+    Values are `bool`
+
+    :param int register_address: The register address to read the bit from
+    :param type bit: The bit index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+
+    """
+    def __set__(self, obj, value):
+        raise AttributeError()

--- a/adafruit_register/spi_bit.py
+++ b/adafruit_register/spi_bit.py
@@ -55,14 +55,14 @@ class RWBit:
 
     def __get__(self, obj, objtype=None):
         with obj.spi_device as spi:
-            spi.write(self.buffer,end=2)
-            spi.readinto(self.buffer,start=1)
+            spi.write(self.buffer, end=2)
+            spi.readinto(self.buffer, start=1)
         return bool(self.buffer[self.byte] & self.bit_mask)
 
     def __set__(self, obj, value):
         with obj.spi_device as spi:
-            spi.write(self.buffer,end=2)
-            spi.readinto(self.buffer,start=1)
+            spi.write(self.buffer, end=2)
+            spi.readinto(self.buffer, start=1)
             if value:
                 self.buffer[self.byte] |= self.bit_mask
             else:

--- a/adafruit_register/spi_bits.py
+++ b/adafruit_register/spi_bits.py
@@ -58,8 +58,8 @@ class RWBits:
 
     def __get__(self, obj, objtype=None):
         with obj.spi_device as spi:
-            spi.write(self.buffer,end=2)
-            spi.readinto(self.buffer,start=1)
+            spi.write(self.buffer, end=2)
+            spi.readinto(self.buffer, start=1)
         # read the number of bytes into a single variable
         reg = 0
         order = range(len(self.buffer)-1, 0, -1)
@@ -72,8 +72,8 @@ class RWBits:
     def __set__(self, obj, value):
         value <<= self.lowest_bit    # shift the value over to the right spot
         with obj.spi_device as spi:
-            spi.write(self.buffer,end=2)
-            spi.readinto(self.buffer,start=1)
+            spi.write(self.buffer, end=2)
+            spi.readinto(self.buffer, start=1)
             reg = 0
             order = range(len(self.buffer)-1, 0, -1)
             if not self.lsb_first:

--- a/adafruit_register/spi_bits.py
+++ b/adafruit_register/spi_bits.py
@@ -1,0 +1,105 @@
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 Scott Shawcroft for Adafruit Industries
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# pylint: disable=too-few-public-methods
+"""
+`adafruit_register.spi_bits`
+====================================================
+
+Multi bit registers
+
+* Author(s): Scott Shawcroft
+* Adaptation by Max Holliday
+"""
+
+
+class RWBits:
+    """
+    Multibit register (less than a full byte) that is readable and writeable.
+    This must be within a byte register.
+
+    Values are `int` between 0 and 2 ** ``num_bits`` - 1.
+
+    :param int num_bits: The number of bits in the field.
+    :param int register_address: The register address to read the bit from
+    :param type lowest_bit: The lowest bits index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+    :param bool lsb_first: Is the first byte we read from SPI the LSB? Defaults to true
+    """
+    def __init__(self, num_bits, register_address, lowest_bit, # pylint: disable=too-many-arguments
+                 register_width=1, lsb_first=True):
+        self.bit_mask = ((1 << num_bits)-1)  << lowest_bit
+        # print("bitmask: ",hex(self.bit_mask))
+        if self.bit_mask >= 1 << (register_width*8):
+            raise ValueError("Cannot have more bits than register size")
+        self.lowest_bit = lowest_bit
+        self.buffer = bytearray(1 + register_width)
+        self.buffer[0] = register_address
+        self.buffer[1] = register_width-1
+        self.lsb_first = lsb_first
+
+    def __get__(self, obj, objtype=None):
+        with obj.spi_device as spi:
+            spi.write(self.buffer,end=2)
+            spi.readinto(self.buffer,start=1)
+        # read the number of bytes into a single variable
+        reg = 0
+        order = range(len(self.buffer)-1, 0, -1)
+        if not self.lsb_first:
+            order = reversed(order)
+        for i in order:
+            reg = (reg << 8) | self.buffer[i]
+        return (reg & self.bit_mask) >> self.lowest_bit
+
+    def __set__(self, obj, value):
+        value <<= self.lowest_bit    # shift the value over to the right spot
+        with obj.spi_device as spi:
+            spi.write(self.buffer,end=2)
+            spi.readinto(self.buffer,start=1)
+            reg = 0
+            order = range(len(self.buffer)-1, 0, -1)
+            if not self.lsb_first:
+                order = range(1, len(self.buffer))
+            for i in order:
+                reg = (reg << 8) | self.buffer[i]
+            #print("old reg: ", hex(reg))
+            reg &= ~self.bit_mask  # mask off the bits we're about to change
+            reg |= value           # then or in our new value
+            #print("new reg: ", hex(reg))
+            for i in reversed(order):
+                self.buffer[i] = reg & 0xFF
+                reg >>= 8
+            spi.write(self.buffer)
+
+class ROBits(RWBits):
+    """
+    Multibit register (less than a full byte) that is read-only. This must be
+    within a byte register.
+
+    Values are `int` between 0 and 2 ** ``num_bits`` - 1.
+
+    :param int num_bits: The number of bits in the field.
+    :param int register_address: The register address to read the bit from
+    :param type lowest_bit: The lowest bits index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+    """
+    def __set__(self, obj, value):
+        raise AttributeError()


### PR DESCRIPTION
I quickly ported over the I2C bit and bits functionality to SPI devices.

Confirmed working on a handful of SPI devices that expect register interaction with the following format: byte1:`starting register address` byte2:`# of registers minus 1`. Note this is different than I2C where you don't need byte2 and can just clock in/out data. 

A little high-level reworking of the library could likely integrate I2C and SPI together (if someone was motivated). 