### PR TITLE
RWBits: Add support for signed registers

### DIFF
--- a/adafruit_register/i2c_bits.py
+++ b/adafruit_register/i2c_bits.py
@@ -45,7 +45,8 @@ class RWBits:
     :param type lowest_bit: The lowest bits index within the byte at ``register_address``
     :param int register_width: The number of bytes in the register. Defaults to 1.
     :param bool lsb_first: Is the first byte we read from I2C the LSB? Defaults to true
-    :param bool signed: If True, the value is a "two's complement" signed value.  If False, it is unsigned.
+    :param bool signed: If True, the value is a "two's complement" signed value.
+                        If False, it is unsigned.
     """
 
     def __init__(  # pylint: disable=too-many-arguments

--- a/adafruit_register/i2c_bits.py
+++ b/adafruit_register/i2c_bits.py
@@ -49,7 +49,13 @@ class RWBits:
     """
 
     def __init__(  # pylint: disable=too-many-arguments
-        self, num_bits, register_address, lowest_bit, register_width=1, lsb_first=True, signed=False
+        self,
+        num_bits,
+        register_address,
+        lowest_bit,
+        register_width=1,
+        lsb_first=True,
+        signed=False,
     ):
         self.bit_mask = ((1 << num_bits) - 1) << lowest_bit
         # print("bitmask: ",hex(self.bit_mask))
@@ -59,7 +65,7 @@ class RWBits:
         self.buffer = bytearray(1 + register_width)
         self.buffer[0] = register_address
         self.lsb_first = lsb_first
-        self.sign_bit = (1 << (num_bits-1)) if signed else 0
+        self.sign_bit = (1 << (num_bits - 1)) if signed else 0
 
     def __get__(self, obj, objtype=None):
         with obj.i2c_device as i2c:
@@ -74,7 +80,7 @@ class RWBits:
         reg = (reg & self.bit_mask) >> self.lowest_bit
         # If the value is signed and negative, convert it
         if reg & self.sign_bit:
-            reg -= 2*self.sign_bit
+            reg -= 2 * self.sign_bit
         return reg
 
     def __set__(self, obj, value):


### PR DESCRIPTION
An example of a signed register is the calibration value of the PCF8523 real-time clock, which stores values from -64 to +63 in 7 bits.  This could now be specified as
```
calibration = i2c_bits.RWBits(7, 0xe, 0, signed=True)
```

Note that assigning a negative value to an RWBits already worked, regardless of whether the register was signed, so it was already possible to *write* -2 to the register; this just allows it to be read back as -2 instead of 126.