### PR TITLE
Mask registers in BCDDateTimeRegister

### DIFF
--- a/adafruit_register/i2c_bcd_datetime.py
+++ b/adafruit_register/i2c_bcd_datetime.py
@@ -88,13 +88,13 @@ class BCDDateTimeRegister:
             (
                 _bcd2bin(self.buffer[7] & self.mask_datetime[7]) + 2000,
                 _bcd2bin(self.buffer[6] & self.mask_datetime[6]),
-                _bcd2bin(self.buffer[5 - self.weekday_offset] & self.mask_datetime[5]),
+                _bcd2bin(self.buffer[5 - self.weekday_offset] & self.mask_datetime[4]),
                 _bcd2bin(self.buffer[3] & self.mask_datetime[3]),
                 _bcd2bin(self.buffer[2] & self.mask_datetime[2]),
                 _bcd2bin(self.buffer[1] & self.mask_datetime[1]),
                 _bcd2bin(
                     self.buffer[4 + self.weekday_offset]
-                    & self.mask_datetime[4] - self.weekday_start
+                    & self.mask_datetime[5] - self.weekday_start
                 ),
                 -1,
                 -1,

--- a/adafruit_register/i2c_bcd_datetime.py
+++ b/adafruit_register/i2c_bcd_datetime.py
@@ -77,6 +77,8 @@ class BCDDateTimeRegister:
         else:
             self.weekday_offset = 1
         self.weekday_start = weekday_start
+                             #n/a   sec   min   hour  days  wkday  mon  year
+        self.mask_datetime = [0xFF, 0x7F, 0x7F, 0x3F, 0x3F, 0x07, 0x1F, 0xFF]
 
     def __get__(self, obj, objtype=None):
         # Read and return the date and time.
@@ -84,13 +86,13 @@ class BCDDateTimeRegister:
             i2c.write_then_readinto(self.buffer, self.buffer, out_end=1, in_start=1)
         return time.struct_time(
             (
-                _bcd2bin(self.buffer[7]) + 2000,
-                _bcd2bin(self.buffer[6]),
-                _bcd2bin(self.buffer[5 - self.weekday_offset]),
-                _bcd2bin(self.buffer[3]),
-                _bcd2bin(self.buffer[2]),
-                _bcd2bin(self.buffer[1] & 0x7F),
-                _bcd2bin(self.buffer[4 + self.weekday_offset] - self.weekday_start),
+                _bcd2bin(self.buffer[7] & self.mask_datetime[7]) + 2000,
+                _bcd2bin(self.buffer[6] & self.mask_datetime[6]),
+                _bcd2bin(self.buffer[5 - self.weekday_offset] & self.mask_datetime[5]),
+                _bcd2bin(self.buffer[3] & self.mask_datetime[3]),
+                _bcd2bin(self.buffer[2] & self.mask_datetime[2]),
+                _bcd2bin(self.buffer[1] & self.mask_datetime[1]),
+                _bcd2bin(self.buffer[4 + self.weekday_offset] & self.mask_datetime[4] - self.weekday_start),
                 -1,
                 -1,
             )

--- a/adafruit_register/i2c_bcd_datetime.py
+++ b/adafruit_register/i2c_bcd_datetime.py
@@ -77,8 +77,8 @@ class BCDDateTimeRegister:
         else:
             self.weekday_offset = 1
         self.weekday_start = weekday_start
-        # Masking value list  n/a   sec   min   hour  days  wkday  mon  year
-        self.mask_datetime = [0xFF, 0x7F, 0x7F, 0x3F, 0x3F, 0x07, 0x1F, 0xFF]
+        # Masking value list   n/a  sec min hr day wkday mon year
+        self.mask_datetime = b"\xFF\x7F\x7F\x3F\x3F\x07\x1F\xFF"
 
     def __get__(self, obj, objtype=None):
         # Read and return the date and time.

--- a/adafruit_register/i2c_bcd_datetime.py
+++ b/adafruit_register/i2c_bcd_datetime.py
@@ -77,7 +77,7 @@ class BCDDateTimeRegister:
         else:
             self.weekday_offset = 1
         self.weekday_start = weekday_start
-                             #n/a   sec   min   hour  days  wkday  mon  year
+        # Masking value list  n/a   sec   min   hour  days  wkday  mon  year
         self.mask_datetime = [0xFF, 0x7F, 0x7F, 0x3F, 0x3F, 0x07, 0x1F, 0xFF]
 
     def __get__(self, obj, objtype=None):
@@ -92,7 +92,10 @@ class BCDDateTimeRegister:
                 _bcd2bin(self.buffer[3] & self.mask_datetime[3]),
                 _bcd2bin(self.buffer[2] & self.mask_datetime[2]),
                 _bcd2bin(self.buffer[1] & self.mask_datetime[1]),
-                _bcd2bin(self.buffer[4 + self.weekday_offset] & self.mask_datetime[4] - self.weekday_start),
+                _bcd2bin(
+                    self.buffer[4 + self.weekday_offset]
+                    & self.mask_datetime[4] - self.weekday_start
+                ),
                 -1,
                 -1,
             )


### PR DESCRIPTION
Corrects for issue where x bits on the RTC do not return 0. I ran into an error when using the PCF8563 RTC, though the issue is not present on the PCF8523 RTC. This change creates a default masking list that corrects the error. I ran through the simpletest example on both the PCF8523 and PCF8563 for several minutes and did not see an issue.