### PR TITLE
Weekday in i2c_bcd_datetime reading incorrectly.

### DIFF
--- a/adafruit_register/i2c_bcd_datetime.py
+++ b/adafruit_register/i2c_bcd_datetime.py
@@ -76,8 +76,11 @@ class BCDDateTimeRegister:
                 _bcd2bin(self.buffer[2] & self.mask_datetime[2]),
                 _bcd2bin(self.buffer[1] & self.mask_datetime[1]),
                 _bcd2bin(
-                    self.buffer[4 + self.weekday_offset]
-                    & self.mask_datetime[5] - self.weekday_start
+                    (
+                        self.buffer[4 + self.weekday_offset]
+                        & self.mask_datetime[5]
+                    ) 
+                    - self.weekday_start
                 ),
                 -1,
                 -1,

--- a/adafruit_register/i2c_bcd_datetime.py
+++ b/adafruit_register/i2c_bcd_datetime.py
@@ -76,10 +76,7 @@ class BCDDateTimeRegister:
                 _bcd2bin(self.buffer[2] & self.mask_datetime[2]),
                 _bcd2bin(self.buffer[1] & self.mask_datetime[1]),
                 _bcd2bin(
-                    (
-                        self.buffer[4 + self.weekday_offset]
-                        & self.mask_datetime[5]
-                    ) 
+                    (self.buffer[4 + self.weekday_offset] & self.mask_datetime[5])
                     - self.weekday_start
                 ),
                 -1,


### PR DESCRIPTION
While working on a watch with the DS3231 the date was incorrect every other day.

On further inspection, the i2c_bcd_datetime module has a small error, in the __get__ descriptor method has an operator precedence issue. the weekday value should be masked before adjusting for if the weekday starts on a 1 or a 0.

adding parens fixes the issue, tested on the ds3231.