### PR TITLE
Pin circuitpython_typing to min 1.3.1 but not 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@
 Adafruit-Blinka
 adafruit-circuitpython-busdevice
 typing-extensions~=4.0
-adafruit-circuitpython-typing~=1.3
+adafruit-circuitpython-typing>=1.3.1,==1.*


### PR DESCRIPTION
Fixes an issue where `circuitpython_typing` at 1.3.0 caused import failures that were fixed in 1.3.1