### PR TITLE
alarm2 changes

### DIFF
--- a/adafruit_register/i2c_bcd_alarm.py
+++ b/adafruit_register/i2c_bcd_alarm.py
@@ -23,7 +23,7 @@ try:
     from circuitpython_typing.device_drivers import I2CDeviceDriver
 
     FREQUENCY_T = Literal[
-        "monthly", "weekly", "daily", "hourly", "secondly", "minutely"
+        "monthly", "weekly", "daily", "hourly", "minutely", "secondly"
     ]
 except ImportError:
     pass
@@ -115,6 +115,9 @@ class BCDAlarmTimeRegister:
                 frequency = "minutely"
                 seconds = _bcd2bin(self.buffer[1] & 0x7F)
             i = 2
+        else:
+            frequency = "minutely"
+            seconds = _bcd2bin(self.buffer[i] & 0x7F)
         minute = 0
         if (self.buffer[i] & 0x80) == 0:
             frequency = "hourly"
@@ -169,7 +172,7 @@ class BCDAlarmTimeRegister:
             raise ValueError(error_message)
 
         frequency = FREQUENCY.index(frequency_name)
-        if frequency <= 1 and not self.has_seconds:
+        if frequency < 1 and not self.has_seconds:
             raise ValueError(error_message)
 
         # i is the index of the minute byte

--- a/adafruit_register/i2c_bcd_alarm.py
+++ b/adafruit_register/i2c_bcd_alarm.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 # pylint: disable=too-few-public-methods
+# pylint: disable=too-many-branches
 
 """
 `adafruit_register.i2c_bcd_alarm`


### PR DESCRIPTION
ds3231:
minute support
status
frequency re-order

@b-blake provided code from [issue #50](https://github.com/adafruit/Adafruit_CircuitPython_Register/issues/50) 

test script used:

```
import time
import board
import busio
import adafruit_ds3231

i2c = busio.I2C(board.SCL, board.SDA)
rtc = adafruit_ds3231.DS3231(i2c)

# Set Alarm1 to trigger every minute
rtc.alarm2 = (time.struct_time((0, 0, 0, 0, 0, 0, 0, 0, -1)), "minutely")

rtc.alarm2_interrupt = True

def compact(t):
    t = str(t)
    t = t.replace(",", "")
    t = t.replace("'", "")
    t = t.replace("(s", "")
    t = t.replace("(", " ")
    t = t.replace(")", " ")
    t = t.replace("  ", " ")
    t = t.split(' ')
    u = t[0]
    u = u.replace("_", " ")
    t[0] = u[2]
    for v in range(1, 12):
        w = t[v].replace("=", " ")
        w = w.split(' ')
        #print(v, w)
        if   v == 10: t[v-1] = w[0]
        elif v == 11: t[v-1] = w[0]
        else:         t[v-1] = w[1]
        #print(v, t[v])
    print("{0:04}/{1:02}/{2:02} {3:02}:{4:02}:{5:02} {6:} {7:} {8:} {9:} {10:}".format(int(t[0]), int(t[1]), int(t[2]), int(t[3]), int(t[4]), int(t[5]), int(t[6]), int(t[7]), int(t[8]), t[9], t[10]))
    return t
    pass

while True:
    if rtc.alarm2_status:
        print("Alarm triggered!")
        compact(rtc.alarm2)
        rtc.alarm2_status = False  # Clear the alarm status
    time.sleep(1)
```