### PR TITLE
register accessor layer and SPI support

### DIFF
--- a/adafruit_register/register_accessor.py
+++ b/adafruit_register/register_accessor.py
@@ -117,6 +117,8 @@ class I2CRegisterAccessor(RegisterAccessor):
     registers over I2C. This class uses `adafruit_bus_device.I2CDevice` for
     communication. I2CDevice automatically handles the R/W bit by setting
     the lowest bit of the device address to 1 for reading and 0 for writing.
+    Device address & r/w bit will be written first, followed by register address,
+    then the data will be written or read.
 
     :param I2CDevice i2c_device: I2C device to communicate over
     :param int address_width: The number of bytes in the address

--- a/adafruit_register/register_accessor.py
+++ b/adafruit_register/register_accessor.py
@@ -25,6 +25,8 @@ except ImportError:
 
 
 class RegisterAccessor:
+    address_width = None
+
     def _pack_address_into_buffer(self, address, lsb_first, buffer):
         # Pack address into the buffer
         for i in range(self.address_width):
@@ -33,7 +35,9 @@ class RegisterAccessor:
                 buffer[i] = (address >> (i * 8)) & 0xFF
             else:
                 # Big-endian: most significant byte first
-                buffer[i] = (address >> ((address - 1 - i) * 8)) & 0xFF
+                big_endian_address = address.to_bytes(self.address_width, byteorder="big")
+                for address_byte_i in range(self.address_width):
+                    buffer[address_byte_i] = big_endian_address[address_byte_i]
 
 
 class SPIRegisterAccessor(RegisterAccessor):
@@ -74,8 +78,8 @@ class SPIRegisterAccessor(RegisterAccessor):
         self._pack_address_into_buffer(address, lsb_first, buffer)
         self._shift_rw_cmd_bit_into_address_byte(buffer, 1)
         with self.spi_device as spi:
-            spi.write(buffer, end=self.address_width)
-            spi.readinto(buffer, start=self.address_width)
+            spi.write(buffer, end=1)
+            spi.readinto(buffer, start=1)
 
     def write_register(
         self,

--- a/adafruit_register/register_accessor.py
+++ b/adafruit_register/register_accessor.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022 Max Holliday
+# SPDX-FileCopyrightText: Copyright (c) 2025 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+`adafruit_register.register_accessor`
+====================================================
+
+SPI and I2C Register Accessor classes.
+
+* Author(s): Max Holliday
+* Adaptation by Tim Cocks
+"""
+
+
+class SPIRegisterAccessor:
+    def __init__(self, spi_device):
+        self.spi_device = spi_device
+
+    def _shift_rw_cmd_bit_into_address_byte(self, buffer, bit_value):
+        if bit_value not in {0, 1}:
+            raise ValueError("bit_value must be 0 or 1")
+
+        # Clear the MSB (set bit 7 to 0)
+        cleared_byte = buffer[0] & 0x7F
+        # Set the MSB to the desired bit value
+        buffer[0] = cleared_byte | (bit_value << 7)
+
+    def read_register(self, buffer):
+        with self.spi_device as spi:
+            self._shift_rw_cmd_bit_into_address_byte(buffer, 1)
+            spi.write(buffer, end=1)
+            spi.readinto(buffer, start=1)
+
+    def write_register(self, buffer, value, lsb_first, bit_mask, lowest_bit, byte=None):
+        # read current register data
+        with self.spi_device as spi:
+            self._shift_rw_cmd_bit_into_address_byte(buffer, 1)
+            spi.write(buffer, end=1)
+            spi.readinto(buffer, start=1)
+
+        if isinstance(value, int):
+            # shift in integer value to register data
+            reg = 0
+            order = range(len(buffer) - 1, 0, -1)
+            if not lsb_first:
+                order = range(1, len(buffer))
+            for i in order:
+                reg = (reg << 8) | buffer[i]
+
+            shifted_value = value << lowest_bit
+            reg &= ~bit_mask  # mask off the bits we're about to change
+            reg |= shifted_value  # then or in our new value
+
+            # put data from reg back into buffer
+            for i in reversed(order):
+                buffer[i] = reg & 0xFF
+                reg >>= 8
+        elif isinstance(value, bool):
+            # shift in single bit value to register data
+            if value:
+                buffer[byte] |= bit_mask
+            else:
+                buffer[byte] &= ~bit_mask
+
+        # write updated register data
+        with self.spi_device as spi:
+            self._shift_rw_cmd_bit_into_address_byte(buffer, 0)
+            spi.write(buffer)
+
+
+class I2CRegisterAccessor:
+    def __init__(self, bus):
+        pass
+
+    def read_register(self, address):
+        pass
+
+    def write_register(self, address, value):
+        pass

--- a/adafruit_register/register_bit.py
+++ b/adafruit_register/register_bit.py
@@ -43,15 +43,6 @@ class RWBit:
         self.address_width = address_width
         self.buffer = bytearray(address_width + register_width)
 
-        # Pack possible multibyte address into the buffer
-        for i in range(address_width):
-            if lsb_first:
-                # Little-endian: least significant byte first
-                self.buffer[i] = (register_address >> (i * 8)) & 0xFF
-            else:
-                # Big-endian: most significant byte first
-                self.buffer[i] = (register_address >> ((address_width - 1 - i) * 8)) & 0xFF
-
         self.lsb_first = lsb_first
         self.bit_index = bit
         if lsb_first:
@@ -63,14 +54,14 @@ class RWBit:
 
     def __get__(self, obj, objtype=None):
         # read data from register
-        obj.register_accessor.read_register(self.buffer)
+        obj.register_accessor.read_register(self.address, self.lsb_first, self.buffer)
 
         # check specified bit and return boolean
         return bool(self.buffer[self.byte] & self.bit_mask)
 
     def __set__(self, obj, value):
         # read current data from register
-        obj.register_accessor.read_register(self.buffer)
+        obj.register_accessor.read_register(self.address, self.lsb_first, self.buffer)
 
         # update current data with new value
         if value:
@@ -79,7 +70,7 @@ class RWBit:
             self.buffer[self.byte] &= ~self.bit_mask
 
         # write updated data to register
-        obj.register_accessor.write_register(self.buffer)
+        obj.register_accessor.write_register(self.address, self.lsb_first, self.buffer)
 
 
 class ROBit(RWBit):

--- a/adafruit_register/register_bit.py
+++ b/adafruit_register/register_bit.py
@@ -29,39 +29,31 @@ class RWBit:
     """
 
     def __init__(
-        self,
-        register_address: int,
-        bit: int,
-        register_width: int = 1,
-        lsb_first: bool = True,
-        address_width: int = 1,
+        self, register_address: int, bit: int, register_width: int = 1, lsb_first: bool = True
     ):
         self.bit_mask = 1 << (bit % 8)  # the bitmask *within* the byte!
 
         self.address = register_address
 
-        self.address_width = address_width
-        self.buffer = bytearray(address_width + register_width)
+        self.buffer = bytearray(register_width)
 
         self.lsb_first = lsb_first
         self.bit_index = bit
         if lsb_first:
-            self.byte = address_width + (bit // 8)  # Little-endian: bit 0 in first register byte
+            self.byte = bit // 8  # Little-endian: bit 0 in first register byte
         else:
-            self.byte = (
-                address_width + register_width - 1 - (bit // 8)
-            )  # Big-endian: bit 0 in last register byte
+            self.byte = register_width - 1 - (bit // 8)  # Big-endian: bit 0 in last register byte
 
     def __get__(self, obj, objtype=None):
         # read data from register
-        obj.register_accessor.read_register(self.address, self.lsb_first, self.buffer)
+        obj.register_accessor.read_register(self.address, self.buffer)
 
         # check specified bit and return boolean
         return bool(self.buffer[self.byte] & self.bit_mask)
 
     def __set__(self, obj, value):
         # read current data from register
-        obj.register_accessor.read_register(self.address, self.lsb_first, self.buffer)
+        obj.register_accessor.read_register(self.address, self.buffer)
 
         # update current data with new value
         if value:
@@ -70,7 +62,7 @@ class RWBit:
             self.buffer[self.byte] &= ~self.bit_mask
 
         # write updated data to register
-        obj.register_accessor.write_register(self.address, self.lsb_first, self.buffer)
+        obj.register_accessor.write_register(self.address, self.buffer)
 
 
 class ROBit(RWBit):

--- a/adafruit_register/register_bit.py
+++ b/adafruit_register/register_bit.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+`adafruit_register.register_bit`
+====================================================
+
+Single bit registers that use RegisterAccessor
+
+* Author(s): Tim Cocks
+
+"""
+
+
+class RWBit:
+    """
+    Single bit register that is readable and writeable.
+
+    Values are `bool`
+
+    :param int register_address: The register address to read the bit from
+    :param int bit: The bit index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+    :param bool lsb_first: Is the first byte we read from spi the LSB? Defaults to true
+
+    """
+
+    def __init__(self, register_address, bit, register_width=1, lsb_first=True):
+        self.bit_mask = 1 << (bit % 8)  # the bitmask *within* the byte!
+        self.buffer = bytearray(1 + register_width)
+        self.address = register_address
+        self.buffer[0] = register_address
+        self.buffer[1] = register_width - 1
+        self.lsb_first = lsb_first
+        self.bit_index = bit
+        if lsb_first:
+            self.byte = bit // 8 + 1  # the byte number within the buffer
+        else:
+            self.byte = register_width - (bit // 8)  # the byte number within the buffer
+
+    def __get__(self, obj, objtype=None):
+        obj.register_accessor.read_register(self.buffer)
+        return bool(self.buffer[self.byte] & self.bit_mask)
+
+    def __set__(self, obj, value):
+        obj.register_accessor.write_register(
+            self.buffer, value, self.lsb_first, self.bit_mask, self.bit_index, byte=self.byte
+        )
+
+
+class ROBit(RWBit):
+    """Single bit register that is read only. Subclass of `RWBit`.
+
+    Values are `bool`
+
+    :param int register_address: The register address to read the bit from
+    :param type bit: The bit index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+
+    """
+
+    def __set__(self, obj, value):
+        raise AttributeError()

--- a/adafruit_register/register_bit.py
+++ b/adafruit_register/register_bit.py
@@ -11,6 +11,9 @@ Single bit registers that use RegisterAccessor
 
 """
 
+__version__ = "0.0.0+auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Register.git"
+
 
 class RWBit:
     """

--- a/adafruit_register/register_bits.py
+++ b/adafruit_register/register_bits.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Tim Cocks for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+"""
+`adafruit_register.register_bits`
+====================================================
+
+Multi bit registers
+
+* Author(s): Tim Cocks
+
+"""
+
+import time
+
+
+class RWBits:
+    """
+    Multibit register (less than a full byte) that is readable and writeable.
+    This must be within a byte register.
+
+    Values are `int` between 0 and 2 ** ``num_bits`` - 1.
+
+    :param int num_bits: The number of bits in the field.
+    :param int register_address: The register address to read the bit from
+    :param int lowest_bit: The lowest bits index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+    :param bool lsb_first: Is the first byte we read from SPI the LSB? Defaults to true
+    """
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        num_bits,
+        register_address,
+        lowest_bit,
+        register_width=1,
+        lsb_first=True,
+    ):
+        self.bit_mask = ((1 << num_bits) - 1) << lowest_bit
+
+        if self.bit_mask >= 1 << (register_width * 8):
+            raise ValueError("Cannot have more bits than register size")
+        self.lowest_bit = lowest_bit
+        self.buffer = bytearray(1 + register_width)
+        self.buffer[0] = register_address
+        self.buffer[1] = register_width - 1
+        self.lsb_first = lsb_first
+
+    def __get__(self, obj, objtype=None):
+        obj.register_accessor.read_register(self.buffer)
+
+        # read the bytes into a single variable
+        reg = 0
+        order = range(len(self.buffer) - 1, 0, -1)
+        if not self.lsb_first:
+            order = reversed(order)
+        for i in order:
+            reg = (reg << 8) | self.buffer[i]
+
+        # extract integer value from specified bits
+        result = (reg & self.bit_mask) >> self.lowest_bit
+        return result
+
+    def __set__(self, obj, value):
+        obj.register_accessor.write_register(
+            self.buffer, value, self.lsb_first, self.bit_mask, self.lowest_bit
+        )
+
+
+class ROBits(RWBits):
+    """
+    Multibit register (less than a full byte) that is read-only. This must be
+    within a byte register.
+
+    Values are `int` between 0 and 2 ** ``num_bits`` - 1.
+
+    :param int num_bits: The number of bits in the field.
+    :param int register_address: The register address to read the bit from
+    :param type lowest_bit: The lowest bits index within the byte at ``register_address``
+    :param int register_width: The number of bytes in the register. Defaults to 1.
+    """
+
+    def __set__(self, obj, value):
+        raise AttributeError()

--- a/adafruit_register/register_bits.py
+++ b/adafruit_register/register_bits.py
@@ -11,7 +11,8 @@ Multi bit registers
 
 """
 
-import time
+__version__ = "0.0.0+auto.0"
+__repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_Register.git"
 
 
 class RWBits:

--- a/adafruit_register/register_bits.py
+++ b/adafruit_register/register_bits.py
@@ -27,33 +27,47 @@ class RWBits:
     :param int lowest_bit: The lowest bits index within the byte at ``register_address``
     :param int register_width: The number of bytes in the register. Defaults to 1.
     :param bool lsb_first: Is the first byte we read from SPI the LSB? Defaults to true
+    :param int address_width: The width of the register address in bytes. Defaults to 1.
     """
 
     # pylint: disable=too-many-arguments
     def __init__(
         self,
-        num_bits,
-        register_address,
-        lowest_bit,
-        register_width=1,
-        lsb_first=True,
+        num_bits: int,
+        register_address: int,
+        lowest_bit: int,
+        register_width: int = 1,
+        lsb_first: bool = True,
+        address_width: int = 1,
     ):
         self.bit_mask = ((1 << num_bits) - 1) << lowest_bit
 
         if self.bit_mask >= 1 << (register_width * 8):
             raise ValueError("Cannot have more bits than register size")
         self.lowest_bit = lowest_bit
-        self.buffer = bytearray(1 + register_width)
-        self.buffer[0] = register_address
-        self.buffer[1] = register_width - 1
+
+        self.address_width = address_width
+        self.buffer = bytearray(address_width + register_width)
+
+        # Pack possible multibyte address into the buffer
+        for i in range(address_width):
+            if lsb_first:
+                # Little-endian: least significant byte first
+                self.buffer[i] = (register_address >> (i * 8)) & 0xFF
+            else:
+                # Big-endian: most significant byte first
+                self.buffer[i] = (register_address >> ((address_width - 1 - i) * 8)) & 0xFF
+
+        # self.buffer[1] = register_width - 1
         self.lsb_first = lsb_first
 
     def __get__(self, obj, objtype=None):
+        # read data from register
         obj.register_accessor.read_register(self.buffer)
 
         # read the bytes into a single variable
         reg = 0
-        order = range(len(self.buffer) - 1, 0, -1)
+        order = range(len(self.buffer) - 1, self.address_width - 1, -1)
         if not self.lsb_first:
             order = reversed(order)
         for i in order:
@@ -64,9 +78,27 @@ class RWBits:
         return result
 
     def __set__(self, obj, value):
-        obj.register_accessor.write_register(
-            self.buffer, value, self.lsb_first, self.bit_mask, self.lowest_bit
-        )
+        # read current data from register
+        obj.register_accessor.read_register(self.buffer)
+
+        # shift in integer value to register data
+        reg = 0
+        order = range(len(self.buffer) - 1, self.address_width - 1, -1)
+        if not self.lsb_first:
+            order = range(1, len(self.buffer))
+        for i in order:
+            reg = (reg << 8) | self.buffer[i]
+        shifted_value = value << self.lowest_bit
+        reg &= ~self.bit_mask  # mask off the bits we're about to change
+        reg |= shifted_value  # then or in our new value
+
+        # put data from reg back into buffer
+        for i in reversed(order):
+            self.buffer[i] = reg & 0xFF
+            reg >>= 8
+
+        # write updated data into the register
+        obj.register_accessor.write_register(self.buffer)
 
 
 class ROBits(RWBits):

--- a/examples/register_accessor_multibyte_address_test.py
+++ b/examples/register_accessor_multibyte_address_test.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025 Tim Cocks for Adafruit Industries
+# SPDX-License-Identifier: MIT
+"""
+Verify functionality of multibyte address registers.
+
+Rrequires OV5640 camera connected.
+Default pins are for RPi Pico + Adafruit PiCowbell Camera Breakout
+"""
+
+import board
+import busio
+import digitalio
+from adafruit_bus_device.i2c_device import I2CDevice
+
+from adafruit_register.register_accessor import I2CRegisterAccessor
+from adafruit_register.register_bits import ROBits
+
+I2C_ADDRESS = 0x3C
+REG_CHIP_ID_HIGH = 0x300A
+
+
+class OV5640Tester:
+    chip_id = ROBits(16, REG_CHIP_ID_HIGH, 0, register_width=2, lsb_first=False)
+
+    def __init__(self, i2c):
+        try:
+            i2c_device = I2CDevice(i2c, I2C_ADDRESS)
+            self.register_accessor = I2CRegisterAccessor(
+                i2c_device, address_width=2, lsb_first=False
+            )
+        except ValueError:
+            raise ValueError(f"No I2C device found.")
+
+
+if __name__ == "__main__":
+    print("construct bus")
+    i2c = busio.I2C(board.GP5, board.GP4)
+    print("construct camera")
+    reset = digitalio.DigitalInOut(board.GP14)
+
+    ov5640 = OV5640Tester(i2c)
+    print(hex(ov5640.chip_id))


### PR DESCRIPTION
Only SPI is implemented right now, I'll work on I2C next.

Adds new RegisterAccessor classes which RWBits and RWBit use so that they are agnostic to bus type. 

I have successfully tested with a development version of the bmp5xx driver. I'll submit a PR over in that repo soon with the driver that relies on this new functionality.

Marking this draft until I2C is implemented, but wanted to get it opened now for any feedback.